### PR TITLE
Fix : Check parameters type - php 8+

### DIFF
--- a/src/IIIF/Utils/ArrayCreator.php
+++ b/src/IIIF/Utils/ArrayCreator.php
@@ -82,13 +82,13 @@ class ArrayCreator {
     {
         if (is_array($value)) {
           foreach($value as &$class) {
-            if (method_exists($class, "toArray")) {
+            if ((is_object($class) || is_string($class)) && method_exists($class, "toArray")) {
               $class = $class->toArray();
             }
           }
         }
         else {
-         if (method_exists($value, "toArray")) {
+         if ((is_object($value) || is_string($value)) && method_exists($value, "toArray")) {
            $value = $value->toArray();
          }
         }


### PR DESCRIPTION
When using php 8.0+ there is an error when we pass an integer or other than string/object variable in the function method_exists(). 

As this function accepts only object or string for the first parameter, i think we should add this check.